### PR TITLE
Improve assertion message for title task

### DIFF
--- a/test/index_test.js
+++ b/test/index_test.js
@@ -21,7 +21,7 @@ describe('Your HTML Page', function() {
     assert.equal(window.$('title').length, 1, 'Make sure to create a `title` element.');
   });
 
-  it('should have a title with the text "Code School" @title', function() {
+  it('should have a title that contains your name @title', function() {
     assert.notEqual(window.$('title').text(), '', 'Make sure to set the content of the `title` element to your Code School username.');
   });
 


### PR DESCRIPTION
On the CodeSchool website, the task #5 asks students to add their name as the content for the title element, however the test message asks them to add the text "Code School" instead, which can be confusing.

This change makes the message consistent with the tasks required from the CodeSchool website.

![codeschool-screenshot](https://cloud.githubusercontent.com/assets/5503784/21017999/e1a4f968-bd30-11e6-8402-cf1526dcc741.png)
